### PR TITLE
v1: Pipeline scaffolding (closes #4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# AWS credentials for Bedrock access.
+# Copy this file to `.env` and fill in real values; `.env` is gitignored.
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+AWS_SESSION_TOKEN=
+AWS_REGION=us-east-1
+
+# Bedrock model used by the LLM stage of PipelineV1.
+# Override via config.yaml or this env var.
+BEDROCK_MODEL_ID=anthropic.claude-3-5-sonnet-20241022-v2:0
+
+# Optional: path to a custom pipeline config file (defaults to ./config.yaml).
+PDFTOXL_CONFIG=

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ build/
 dist/
 .DS_Store
 evals/reports/
+.env
+

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,41 @@
+# PipelineV1 configuration.
+# Anything here can be overridden with CLI flags (--config path) or env vars
+# prefixed with PDFTOXL_ (e.g. PDFTOXL_BEDROCK__MODEL_ID).
+
+pipeline_version: "v1"
+
+bedrock:
+  # Bedrock model invoked by the LLM stage.
+  model_id: "amazon.nova-2-lite-v1:0"
+  region: "us-west-2"
+  max_tokens: 4096
+  temperature: 0.0
+  # Optional per-request timeout (seconds).
+  timeout_seconds: 60
+
+stages:
+  # Toggle individual stages on/off while iterating on the pipeline.
+  extraction: true
+  classification: true
+  gate: true
+  llm: true
+  merge: true
+  mapping: true
+  output: true
+
+thresholds:
+  # Confidence cutoff for the rule/LLM gate stage.
+  gate_confidence: 0.75
+  # Minimum per-block confidence retained after merge.
+  min_block_confidence: 0.05
+
+paths:
+  fixtures_yaml: "evals/fixtures.yaml"
+  # Template workbook used when a fixture's golden is unavailable.
+  # Leave empty to require the fixture's golden_xlsx_path.
+  default_template_xlsx: ""
+
+logging:
+  level: "INFO"
+  # "console" for human-readable, "json" for structured.
+  renderer: "console"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,14 @@ requires-python = ">=3.11"
 dependencies = [
     "openpyxl>=3.1",
     "pydantic>=2.5",
+    "pydantic-settings>=2.2",
     "pyyaml>=6.0",
     "typer>=0.12",
     "rapidfuzz>=3.6",
     "python-dateutil>=2.8",
+    "python-dotenv>=1.0",
+    "structlog>=24.1",
+    "boto3>=1.34",
 ]
 
 [project.optional-dependencies]
@@ -21,6 +25,7 @@ dev = ["pytest>=8.0", "ruff>=0.5"]
 
 [project.scripts]
 pdftoxl-evals = "pdftoxl.evals.cli:app"
+pdftoxl = "pdftoxl.cli:app"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -38,6 +43,7 @@ ignore = ["E501"]
 
 [tool.ruff.lint.per-file-ignores]
 "src/pdftoxl/evals/cli.py" = ["B008"]
+"src/pdftoxl/cli.py" = ["B008"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/pdftoxl/adapters/__init__.py
+++ b/src/pdftoxl/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""External-package adapters.
+
+Kept outside `pipeline_v1/` so pipeline stages depend on thin interfaces,
+not on third-party SDKs directly. Swap an implementation here to re-point
+the pipeline at a different backend without touching stage code.
+"""

--- a/src/pdftoxl/adapters/bedrock.py
+++ b/src/pdftoxl/adapters/bedrock.py
@@ -1,0 +1,67 @@
+"""AWS Bedrock adapter.
+
+Thin wrapper around boto3 so pipeline stages never import boto3 directly.
+Credentials are resolved by boto3's default chain (env vars from `.env`,
+shared credentials file, IAM role, etc.).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+class LLMClient(Protocol):
+    def invoke(self, prompt: str, *, system: str | None = None) -> str: ...
+
+
+@dataclass(frozen=True)
+class BedrockSettings:
+    model_id: str
+    region: str
+    max_tokens: int = 4096
+    temperature: float = 0.0
+    timeout_seconds: int = 60
+
+
+class BedrockClient:
+    """Invokes Anthropic models on AWS Bedrock via the Messages API."""
+
+    def __init__(self, settings: BedrockSettings, *, client: Any | None = None) -> None:
+        self._settings = settings
+        self._client = client or self._build_client(settings)
+
+    @staticmethod
+    def _build_client(settings: BedrockSettings) -> Any:
+        import boto3
+        from botocore.config import Config
+
+        return boto3.client(
+            "bedrock-runtime",
+            region_name=settings.region,
+            config=Config(read_timeout=settings.timeout_seconds),
+        )
+
+    def invoke(self, prompt: str, *, system: str | None = None) -> str:
+        body: dict[str, Any] = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": self._settings.max_tokens,
+            "temperature": self._settings.temperature,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if system:
+            body["system"] = system
+
+        response = self._client.invoke_model(
+            modelId=self._settings.model_id,
+            body=json.dumps(body),
+            contentType="application/json",
+            accept="application/json",
+        )
+        payload = json.loads(response["body"].read())
+        parts = payload.get("content", [])
+        return "".join(p.get("text", "") for p in parts if p.get("type") == "text")
+
+
+def build_bedrock_client(settings: BedrockSettings) -> LLMClient:
+    return BedrockClient(settings)

--- a/src/pdftoxl/adapters/env.py
+++ b/src/pdftoxl/adapters/env.py
@@ -1,0 +1,13 @@
+"""Load .env into os.environ. Kept here so pipeline code never imports dotenv."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def load_env(dotenv_path: Path | None = None) -> None:
+    from dotenv import load_dotenv
+
+    path = dotenv_path or Path(os.environ.get("PDFTOXL_DOTENV", ".env"))
+    if path.exists():
+        load_dotenv(path, override=False)

--- a/src/pdftoxl/adapters/logging.py
+++ b/src/pdftoxl/adapters/logging.py
@@ -1,0 +1,35 @@
+"""structlog configuration."""
+from __future__ import annotations
+
+import logging
+import sys
+
+import structlog
+
+
+def configure_logging(level: str = "INFO", renderer: str = "console") -> None:
+    logging.basicConfig(
+        format="%(message)s",
+        stream=sys.stderr,
+        level=getattr(logging, level.upper(), logging.INFO),
+    )
+    processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+    ]
+    if renderer == "json":
+        processors.append(structlog.processors.JSONRenderer())
+    else:
+        processors.append(structlog.dev.ConsoleRenderer())
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(
+            getattr(logging, level.upper(), logging.INFO)
+        ),
+        cache_logger_on_first_use=True,
+    )
+
+
+def get_logger(stage: str) -> structlog.stdlib.BoundLogger:
+    return structlog.get_logger().bind(stage=stage)

--- a/src/pdftoxl/cli.py
+++ b/src/pdftoxl/cli.py
@@ -1,0 +1,54 @@
+"""`pdftoxl` CLI — runs PipelineV1 end-to-end on a fixture."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from .adapters.env import load_env
+from .adapters.logging import configure_logging
+from .evals.fixtures import find_fixture, load_fixtures
+from .pipeline_v1 import load_config
+from .pipeline_v1.pipeline import PipelineContext, build_pipeline
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+@app.callback()
+def _root() -> None:
+    """pdftoxl pipeline CLI."""
+
+
+@app.command("run")
+def run(
+    fixture: str = typer.Option(..., "--fixture", help="Fixture ID (see evals/fixtures.yaml)."),
+    out: Path = typer.Option(..., "--out", help="Path for the generated .xlsx."),
+    config: Path | None = typer.Option(None, "--config", help="Pipeline config YAML."),
+    fixtures_yaml: Path | None = typer.Option(None, "--fixtures-yaml"),
+    with_llm: bool = typer.Option(False, "--with-llm", help="Enable Bedrock LLM stage."),
+) -> None:
+    load_env()
+    cfg = load_config(config)
+    configure_logging(level=cfg.logging.level, renderer=cfg.logging.renderer)
+
+    fx_yaml = fixtures_yaml or cfg.paths.fixtures_yaml
+    fixtures = load_fixtures(fx_yaml)
+    fx = find_fixture(fixtures, fixture)
+
+    ctx = PipelineContext(
+        out_path=out,
+        template_xlsx=fx.golden_xlsx_path,
+        question_sheet=fx.question_sheet,
+        header_row=fx.header_row,
+    )
+    pipeline = build_pipeline(cfg, ctx, with_llm=with_llm)
+    written = pipeline(fx.pdf_path)
+    typer.echo(str(written))
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdftoxl/pipeline_v1/__init__.py
+++ b/src/pdftoxl/pipeline_v1/__init__.py
@@ -1,0 +1,10 @@
+"""v1 of the PDF → EAB-Excel pipeline.
+
+Stages (see sibling modules): extraction → classification → gate → llm →
+merge → mapping → output. Each stage is a pure function consuming the
+previous stage's artifact so they can be developed and tested in isolation.
+"""
+from .config import PipelineConfig, load_config
+from .pipeline import PipelineV1, build_pipeline
+
+__all__ = ["PipelineV1", "PipelineConfig", "build_pipeline", "load_config"]

--- a/src/pdftoxl/pipeline_v1/config.py
+++ b/src/pdftoxl/pipeline_v1/config.py
@@ -1,0 +1,82 @@
+"""Pipeline configuration model and loader.
+
+Precedence (highest first): explicit CLI `--config` file → PDFTOXL_CONFIG env
+→ `./config.yaml` → built-in defaults. Environment variables prefixed with
+`PDFTOXL_` override any nested field (use `__` as the delimiter, e.g.
+`PDFTOXL_BEDROCK__MODEL_ID`).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class BedrockConfig(BaseModel):
+    model_id: str = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    region: str = "us-east-1"
+    max_tokens: int = 4096
+    temperature: float = 0.0
+    timeout_seconds: int = 60
+
+
+class StageToggles(BaseModel):
+    extraction: bool = True
+    classification: bool = True
+    gate: bool = True
+    llm: bool = True
+    merge: bool = True
+    mapping: bool = True
+    output: bool = True
+
+
+class Thresholds(BaseModel):
+    gate_confidence: float = 0.75
+    min_block_confidence: float = 0.05
+
+
+class Paths(BaseModel):
+    fixtures_yaml: Path = Path("evals/fixtures.yaml")
+    default_template_xlsx: Path | None = None
+
+
+class LoggingConfig(BaseModel):
+    level: str = "INFO"
+    renderer: str = "console"
+
+
+class PipelineConfig(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PDFTOXL_",
+        env_nested_delimiter="__",
+        extra="ignore",
+    )
+
+    pipeline_version: str = "v1"
+    bedrock: BedrockConfig = Field(default_factory=BedrockConfig)
+    stages: StageToggles = Field(default_factory=StageToggles)
+    thresholds: Thresholds = Field(default_factory=Thresholds)
+    paths: Paths = Field(default_factory=Paths)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+
+
+def _default_config_path() -> Path | None:
+    env = os.environ.get("PDFTOXL_CONFIG")
+    if env:
+        return Path(env)
+    local = Path("config.yaml")
+    return local if local.exists() else None
+
+
+def load_config(path: Path | None = None) -> PipelineConfig:
+    cfg_path = path or _default_config_path()
+    data: dict[str, Any] = {}
+    if cfg_path and Path(cfg_path).exists():
+        with open(cfg_path) as fh:
+            data = yaml.safe_load(fh) or {}
+    # Env vars still override file values (BaseSettings will merge).
+    return PipelineConfig(**data)

--- a/src/pdftoxl/pipeline_v1/pipeline.py
+++ b/src/pdftoxl/pipeline_v1/pipeline.py
@@ -1,0 +1,99 @@
+"""PipelineV1: stitches stages together. Satisfies the `Pipeline` protocol."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..adapters.bedrock import BedrockSettings, LLMClient, build_bedrock_client
+from ..adapters.logging import get_logger
+from .config import PipelineConfig
+from .stages import classification, extraction, gate, llm, mapping, merge, output
+
+log = get_logger("pipeline_v1")
+
+
+@dataclass
+class PipelineContext:
+    """Per-run inputs the stages need beyond the PDF itself.
+
+    The golden workbook stands in as the template until the mapping stage
+    is implemented; any caller can override with a neutral template.
+    """
+
+    out_path: Path
+    template_xlsx: Path
+    question_sheet: str
+    header_row: int
+
+
+class PipelineV1:
+    """Concrete `Pipeline` implementation. Currently a no-op end-to-end."""
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        context: PipelineContext,
+        *,
+        llm_client: LLMClient | None = None,
+    ) -> None:
+        self.config = config
+        self.context = context
+        self._llm_client = llm_client
+
+    def __call__(self, pdf_path: Path) -> Path:
+        log.info("run.start", pdf=str(pdf_path), out=str(self.context.out_path))
+        cfg = self.config
+
+        raw = extraction.run(pdf_path) if cfg.stages.extraction else extraction.RawBlocks(pdf_path, [])
+        classified = (
+            classification.run(raw)
+            if cfg.stages.classification
+            else classification.ClassifiedBlocks(raw.blocks)
+        )
+        gated = (
+            gate.run(classified, confidence_threshold=cfg.thresholds.gate_confidence)
+            if cfg.stages.gate
+            else gate.GateOutput(accepted=classified.blocks)
+        )
+        llm_out = (
+            llm.run(gated, self._llm_client)
+            if cfg.stages.llm
+            else llm.LLMOutput(enriched=gated.deferred)
+        )
+        merged = (
+            merge.run(gated, llm_out, min_confidence=cfg.thresholds.min_block_confidence)
+            if cfg.stages.merge
+            else merge.MergedBlocks(blocks=[*gated.accepted, *llm_out.enriched])
+        )
+        mapped = mapping.run(merged) if cfg.stages.mapping else mapping.MappedRows()
+        out = output.run(
+            mapped,
+            out_path=self.context.out_path,
+            template_xlsx=self.context.template_xlsx,
+            question_sheet=self.context.question_sheet,
+            header_row=self.context.header_row,
+        )
+        log.info("run.done", out=str(out))
+        return out
+
+
+def build_pipeline(
+    config: PipelineConfig,
+    context: PipelineContext,
+    *,
+    with_llm: bool = False,
+) -> PipelineV1:
+    """Construct a PipelineV1. Only instantiates the Bedrock client if asked,
+    so tests and offline runs don't need AWS credentials."""
+    client: LLMClient | None = None
+    if with_llm and config.stages.llm:
+        client = build_bedrock_client(
+            BedrockSettings(
+                model_id=config.bedrock.model_id,
+                region=config.bedrock.region,
+                max_tokens=config.bedrock.max_tokens,
+                temperature=config.bedrock.temperature,
+                timeout_seconds=config.bedrock.timeout_seconds,
+            )
+        )
+    return PipelineV1(config, context, llm_client=client)

--- a/src/pdftoxl/pipeline_v1/stages/__init__.py
+++ b/src/pdftoxl/pipeline_v1/stages/__init__.py
@@ -1,0 +1,4 @@
+"""Pipeline stages. Each module exposes a single `run(...)` function."""
+from . import classification, extraction, gate, llm, mapping, merge, output
+
+__all__ = ["extraction", "classification", "gate", "llm", "merge", "mapping", "output"]

--- a/src/pdftoxl/pipeline_v1/stages/classification.py
+++ b/src/pdftoxl/pipeline_v1/stages/classification.py
@@ -1,0 +1,19 @@
+"""Stage 2: rule-based block classification. No-op scaffold."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...adapters.logging import get_logger
+from .extraction import RawBlocks
+
+log = get_logger("classification")
+
+
+@dataclass
+class ClassifiedBlocks:
+    blocks: list[dict]
+
+
+def run(raw: RawBlocks) -> ClassifiedBlocks:
+    log.info("classify", n=len(raw.blocks))
+    return ClassifiedBlocks(blocks=raw.blocks)

--- a/src/pdftoxl/pipeline_v1/stages/extraction.py
+++ b/src/pdftoxl/pipeline_v1/stages/extraction.py
@@ -1,0 +1,20 @@
+"""Stage 1: raw-block extraction from the PDF. No-op scaffold."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ...adapters.logging import get_logger
+
+log = get_logger("extraction")
+
+
+@dataclass
+class RawBlocks:
+    pdf_path: Path
+    blocks: list[dict]
+
+
+def run(pdf_path: Path) -> RawBlocks:
+    log.info("extract", pdf=str(pdf_path))
+    return RawBlocks(pdf_path=pdf_path, blocks=[])

--- a/src/pdftoxl/pipeline_v1/stages/gate.py
+++ b/src/pdftoxl/pipeline_v1/stages/gate.py
@@ -1,0 +1,27 @@
+"""Stage 3: confidence gate splitting high-confidence from LLM-bound blocks."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ...adapters.logging import get_logger
+from .classification import ClassifiedBlocks
+
+log = get_logger("gate")
+
+
+@dataclass
+class GateOutput:
+    accepted: list[dict] = field(default_factory=list)
+    deferred: list[dict] = field(default_factory=list)
+
+
+def run(classified: ClassifiedBlocks, *, confidence_threshold: float) -> GateOutput:
+    accepted: list[dict] = []
+    deferred: list[dict] = []
+    for b in classified.blocks:
+        if b.get("confidence", 0.0) >= confidence_threshold:
+            accepted.append(b)
+        else:
+            deferred.append(b)
+    log.info("gate", accepted=len(accepted), deferred=len(deferred))
+    return GateOutput(accepted=accepted, deferred=deferred)

--- a/src/pdftoxl/pipeline_v1/stages/llm.py
+++ b/src/pdftoxl/pipeline_v1/stages/llm.py
@@ -1,0 +1,25 @@
+"""Stage 4: LLM enrichment for low-confidence blocks via Bedrock."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...adapters.bedrock import LLMClient
+from ...adapters.logging import get_logger
+from .gate import GateOutput
+
+log = get_logger("llm")
+
+
+@dataclass
+class LLMOutput:
+    enriched: list[dict]
+
+
+def run(gate_out: GateOutput, client: LLMClient | None) -> LLMOutput:
+    if client is None or not gate_out.deferred:
+        log.info("llm.skip", deferred=len(gate_out.deferred), has_client=client is not None)
+        return LLMOutput(enriched=gate_out.deferred)
+
+    log.info("llm.invoke", n=len(gate_out.deferred))
+    # Real prompts land in a later issue; scaffold keeps blocks unchanged.
+    return LLMOutput(enriched=gate_out.deferred)

--- a/src/pdftoxl/pipeline_v1/stages/mapping.py
+++ b/src/pdftoxl/pipeline_v1/stages/mapping.py
@@ -1,0 +1,19 @@
+"""Stage 6: map merged blocks to EAB-Excel rows (28-column contract)."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ...adapters.logging import get_logger
+from .merge import MergedBlocks
+
+log = get_logger("mapping")
+
+
+@dataclass
+class MappedRows:
+    rows: list[dict] = field(default_factory=list)
+
+
+def run(merged: MergedBlocks) -> MappedRows:
+    log.info("map", n=len(merged.blocks))
+    return MappedRows(rows=[])

--- a/src/pdftoxl/pipeline_v1/stages/merge.py
+++ b/src/pdftoxl/pipeline_v1/stages/merge.py
@@ -1,0 +1,22 @@
+"""Stage 5: merge gate-accepted + LLM-enriched blocks into a single stream."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ...adapters.logging import get_logger
+from .gate import GateOutput
+from .llm import LLMOutput
+
+log = get_logger("merge")
+
+
+@dataclass
+class MergedBlocks:
+    blocks: list[dict]
+
+
+def run(gate_out: GateOutput, llm_out: LLMOutput, *, min_confidence: float) -> MergedBlocks:
+    combined = [*gate_out.accepted, *llm_out.enriched]
+    filtered = [b for b in combined if b.get("confidence", 1.0) >= min_confidence]
+    log.info("merge", total=len(combined), kept=len(filtered))
+    return MergedBlocks(blocks=filtered)

--- a/src/pdftoxl/pipeline_v1/stages/output.py
+++ b/src/pdftoxl/pipeline_v1/stages/output.py
@@ -1,0 +1,43 @@
+"""Stage 7: write the mapped rows into a workbook.
+
+Until mapping is implemented the output is a clone of the golden template
+with the question rows cleared below the header. That keeps the workbook
+valid/openable while producing an empty candidate the evals can score.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+from ...adapters.logging import get_logger
+from .mapping import MappedRows
+
+log = get_logger("output")
+
+
+def run(
+    mapped: MappedRows,
+    *,
+    out_path: Path,
+    template_xlsx: Path,
+    question_sheet: str,
+    header_row: int,
+) -> Path:
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(template_xlsx, out_path)
+
+    wb = load_workbook(out_path)
+    if question_sheet in wb.sheetnames:
+        ws = wb[question_sheet]
+        # Clear rows below the header so candidate starts empty.
+        for row in ws.iter_rows(min_row=header_row + 1):
+            for cell in row:
+                cell.value = None
+
+    # `mapped.rows` is empty in the scaffold; a later issue fills the sheet.
+    wb.save(out_path)
+    log.info("output", out=str(out_path), rows=len(mapped.rows))
+    return out_path

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,0 +1,74 @@
+"""Integration tests for the `pdftoxl` CLI."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from openpyxl import load_workbook
+from typer.testing import CliRunner
+
+from pdftoxl.cli import app
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_YAML = REPO_ROOT / "evals" / "fixtures.yaml"
+
+runner = CliRunner()
+
+
+def test_cli_run_writes_workbook(tmp_path):
+    out = tmp_path / "out.xlsx"
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--fixture", "FX-TXLTSS-001",
+            "--out", str(out),
+            "--fixtures-yaml", str(FIXTURES_YAML),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    # CLI prints the written path on success.
+    assert str(out) in result.stdout
+    wb = load_workbook(out)
+    assert "Assessment" in wb.sheetnames
+
+
+def test_cli_run_accepts_custom_config(tmp_path):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        "stages:\n"
+        "  llm: false\n"
+        "logging:\n"
+        "  level: WARNING\n"
+    )
+    out = tmp_path / "out.xlsx"
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--fixture", "FX-TXLTSS-001",
+            "--out", str(out),
+            "--fixtures-yaml", str(FIXTURES_YAML),
+            "--config", str(cfg),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+
+
+def test_cli_missing_fixture_fails_nonzero(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--fixture", "FX-DOES-NOT-EXIST",
+            "--out", str(tmp_path / "out.xlsx"),
+            "--fixtures-yaml", str(FIXTURES_YAML),
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_no_args_shows_help():
+    result = runner.invoke(app, [])
+    assert result.exit_code != 0 or "Usage" in result.output

--- a/tests/integration/test_pipeline_v1_smoke.py
+++ b/tests/integration/test_pipeline_v1_smoke.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+from pdftoxl.evals.fixtures import find_fixture, load_fixtures
+from pdftoxl.evals.metrics.eval_c import run_eval_c
+from pdftoxl.pipeline_v1 import PipelineConfig
+from pdftoxl.pipeline_v1.pipeline import PipelineContext, build_pipeline
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES_YAML = REPO_ROOT / "evals" / "fixtures.yaml"
+
+
+def test_pipeline_v1_writes_openable_workbook(tmp_path):
+    fx = find_fixture(load_fixtures(FIXTURES_YAML), "FX-TXLTSS-001")
+    out = tmp_path / "out.xlsx"
+    cfg = PipelineConfig()
+    ctx = PipelineContext(
+        out_path=out,
+        template_xlsx=fx.golden_xlsx_path,
+        question_sheet=fx.question_sheet,
+        header_row=fx.header_row,
+    )
+    pipeline = build_pipeline(cfg, ctx, with_llm=False)
+    written = pipeline(fx.pdf_path)
+    assert written == out
+    assert out.exists()
+    wb = load_workbook(out)
+    assert fx.question_sheet in wb.sheetnames
+
+
+def test_pipeline_v1_satisfies_protocol(tmp_path):
+    """PipelineV1 is accepted by the eval runner that expects the Pipeline protocol."""
+    fx = find_fixture(load_fixtures(FIXTURES_YAML), "FX-TXLTSS-001")
+    out = tmp_path / "out.xlsx"
+    ctx = PipelineContext(
+        out_path=out,
+        template_xlsx=fx.golden_xlsx_path,
+        question_sheet=fx.question_sheet,
+        header_row=fx.header_row,
+    )
+    pipeline = build_pipeline(PipelineConfig(), ctx, with_llm=False)
+    # Must not raise — structural typing only.
+    result = run_eval_c(fx, pipeline)
+    assert result.fixture_id == fx.id

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -1,0 +1,150 @@
+"""Tests for the adapters: env loader, logging config, Bedrock wrapper."""
+from __future__ import annotations
+
+import json
+
+from pdftoxl.adapters.bedrock import (
+    BedrockClient,
+    BedrockSettings,
+    build_bedrock_client,
+)
+from pdftoxl.adapters.env import load_env
+from pdftoxl.adapters.logging import configure_logging, get_logger
+
+
+def test_load_env_no_file_is_noop(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PDFTOXL_DOTENV", raising=False)
+    # No .env here; should not raise.
+    load_env()
+
+
+def test_load_env_reads_dotenv(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("MY_TEST_VAR=hello-from-dotenv\n")
+    monkeypatch.delenv("MY_TEST_VAR", raising=False)
+    load_env(env_file)
+    import os
+    assert os.environ.get("MY_TEST_VAR") == "hello-from-dotenv"
+
+
+def test_load_env_honors_dotenv_env_var(tmp_path, monkeypatch):
+    env_file = tmp_path / "custom.env"
+    env_file.write_text("MY_OTHER_VAR=yes\n")
+    monkeypatch.setenv("PDFTOXL_DOTENV", str(env_file))
+    monkeypatch.delenv("MY_OTHER_VAR", raising=False)
+    load_env()
+    import os
+    assert os.environ.get("MY_OTHER_VAR") == "yes"
+
+
+def test_load_env_does_not_override_existing(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("ALREADY_SET=from-dotenv\n")
+    monkeypatch.setenv("ALREADY_SET", "from-process")
+    load_env(env_file)
+    import os
+    assert os.environ["ALREADY_SET"] == "from-process"
+
+
+def test_configure_logging_console_smoke():
+    configure_logging(level="DEBUG", renderer="console")
+    log = get_logger("unit")
+    # Should not raise when emitting a record.
+    log.info("hello", key="value")
+
+
+def test_configure_logging_json_renderer():
+    configure_logging(level="INFO", renderer="json")
+    log = get_logger("unit")
+    log.info("event", k=1)
+
+
+def test_configure_logging_invalid_level_does_not_raise():
+    # The helper uses getattr(..., default=INFO) so an invalid level name
+    # must not crash the process.
+    configure_logging(level="NOT_A_LEVEL", renderer="console")
+    get_logger("unit").info("still-works")
+
+
+def test_get_logger_binds_stage():
+    log = get_logger("my-stage")
+    # structlog BoundLogger exposes `_context` dict with bound values.
+    ctx = log._context if hasattr(log, "_context") else {}
+    assert ctx.get("stage") == "my-stage"
+
+
+class _FakeBody:
+    def __init__(self, payload: dict):
+        self._raw = json.dumps(payload).encode()
+
+    def read(self) -> bytes:
+        return self._raw
+
+
+class _FakeBedrockRuntime:
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.calls: list[dict] = []
+
+    def invoke_model(self, *, modelId, body, contentType, accept):
+        self.calls.append(
+            {"modelId": modelId, "body": body, "contentType": contentType, "accept": accept}
+        )
+        return {"body": _FakeBody(self._payload)}
+
+
+def test_bedrock_client_invoke_builds_messages_body_and_joins_text():
+    fake = _FakeBedrockRuntime(
+        {
+            "content": [
+                {"type": "text", "text": "Hello "},
+                {"type": "tool_use", "text": "IGNORED"},
+                {"type": "text", "text": "world"},
+            ]
+        }
+    )
+    settings = BedrockSettings(model_id="m1", region="us-east-1", max_tokens=256, temperature=0.2)
+    client = BedrockClient(settings, client=fake)
+    result = client.invoke("prompt goes here", system="be brief")
+
+    assert result == "Hello world"
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["modelId"] == "m1"
+    assert call["contentType"] == "application/json"
+    body = json.loads(call["body"])
+    assert body["anthropic_version"] == "bedrock-2023-05-31"
+    assert body["max_tokens"] == 256
+    assert body["temperature"] == 0.2
+    assert body["messages"] == [{"role": "user", "content": "prompt goes here"}]
+    assert body["system"] == "be brief"
+
+
+def test_bedrock_client_omits_system_when_none():
+    fake = _FakeBedrockRuntime({"content": [{"type": "text", "text": "ok"}]})
+    client = BedrockClient(
+        BedrockSettings(model_id="m", region="us-east-1"), client=fake
+    )
+    client.invoke("hi")
+    body = json.loads(fake.calls[0]["body"])
+    assert "system" not in body
+
+
+def test_bedrock_client_empty_content_returns_empty_string():
+    fake = _FakeBedrockRuntime({"content": []})
+    client = BedrockClient(
+        BedrockSettings(model_id="m", region="us-east-1"), client=fake
+    )
+    assert client.invoke("hi") == ""
+
+
+def test_build_bedrock_client_returns_bedrockclient(monkeypatch):
+    """build_bedrock_client builds a real client — patch boto3 so no AWS is touched."""
+    import pdftoxl.adapters.bedrock as mod
+
+    monkeypatch.setattr(
+        mod.BedrockClient, "_build_client", staticmethod(lambda s: object())
+    )
+    client = build_bedrock_client(BedrockSettings(model_id="m", region="us-east-1"))
+    assert isinstance(client, BedrockClient)

--- a/tests/unit/test_pipeline_v1_config.py
+++ b/tests/unit/test_pipeline_v1_config.py
@@ -1,0 +1,101 @@
+"""Tests for pdftoxl.pipeline_v1.config — defaults, YAML loading, env overrides."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from pdftoxl.pipeline_v1.config import (
+    BedrockConfig,
+    PipelineConfig,
+    StageToggles,
+    Thresholds,
+    load_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("PDFTOXL_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_defaults_populate_nested_models():
+    cfg = PipelineConfig()
+    assert cfg.pipeline_version == "v1"
+    assert isinstance(cfg.bedrock, BedrockConfig)
+    assert isinstance(cfg.stages, StageToggles)
+    assert isinstance(cfg.thresholds, Thresholds)
+    assert cfg.stages.extraction is True
+    assert cfg.stages.llm is True
+    assert cfg.thresholds.gate_confidence == 0.75
+    assert cfg.thresholds.min_block_confidence == 0.05
+    assert cfg.bedrock.temperature == 0.0
+
+
+def test_load_config_reads_yaml(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "pipeline_version: v1\n"
+        "bedrock:\n"
+        "  model_id: custom.model-1\n"
+        "  region: us-west-2\n"
+        "stages:\n"
+        "  llm: false\n"
+        "thresholds:\n"
+        "  gate_confidence: 0.5\n"
+    )
+    cfg = load_config(cfg_path)
+    assert cfg.bedrock.model_id == "custom.model-1"
+    assert cfg.bedrock.region == "us-west-2"
+    assert cfg.stages.llm is False
+    assert cfg.stages.extraction is True  # untouched default
+    assert cfg.thresholds.gate_confidence == 0.5
+
+
+def test_load_config_missing_path_returns_defaults(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # no ./config.yaml
+    cfg = load_config(None)
+    assert cfg.bedrock.model_id.startswith("anthropic.")
+    assert cfg.stages.extraction is True
+
+
+def test_load_config_respects_env_var_pointer(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg_path = tmp_path / "alt.yaml"
+    cfg_path.write_text("bedrock:\n  region: eu-west-1\n")
+    monkeypatch.setenv("PDFTOXL_CONFIG", str(cfg_path))
+    cfg = load_config(None)
+    assert cfg.bedrock.region == "eu-west-1"
+
+
+def test_env_nested_override_applies_when_field_absent_from_yaml(tmp_path, monkeypatch):
+    """Env vars populate fields that the YAML file doesn't mention.
+
+    Note: when a field is explicitly set in the YAML, the explicit kwarg beats
+    the env-var source in pydantic-settings' current precedence — documented
+    here so future refactors notice if that changes.
+    """
+    monkeypatch.chdir(tmp_path)
+    cfg_path = tmp_path / "config.yaml"
+    # YAML sets model_id only; region is left to env/default.
+    cfg_path.write_text("bedrock:\n  model_id: yaml-model\n")
+    monkeypatch.setenv("PDFTOXL_BEDROCK__REGION", "ap-south-1")
+    cfg = load_config(cfg_path)
+    assert cfg.bedrock.model_id == "yaml-model"
+    assert cfg.bedrock.region == "ap-south-1"
+
+
+def test_empty_yaml_falls_back_to_defaults(tmp_path):
+    cfg_path = tmp_path / "empty.yaml"
+    cfg_path.write_text("")
+    cfg = load_config(cfg_path)
+    assert cfg.pipeline_version == "v1"
+
+
+def test_paths_default_points_to_fixtures_yaml():
+    cfg = PipelineConfig()
+    assert cfg.paths.fixtures_yaml == Path("evals/fixtures.yaml")

--- a/tests/unit/test_pipeline_v1_pipeline.py
+++ b/tests/unit/test_pipeline_v1_pipeline.py
@@ -1,0 +1,99 @@
+"""Tests for PipelineV1 orchestration: stage toggles and build_pipeline."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from openpyxl import Workbook, load_workbook
+
+from pdftoxl.pipeline_v1 import PipelineConfig
+from pdftoxl.pipeline_v1.pipeline import PipelineContext, PipelineV1, build_pipeline
+
+
+def _template(path: Path, sheet: str, header_row: int) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = sheet
+    for col in range(1, 4):
+        ws.cell(row=header_row, column=col, value=f"H{col}")
+    wb.save(path)
+
+
+@pytest.fixture
+def ctx(tmp_path):
+    template = tmp_path / "tpl.xlsx"
+    _template(template, "Assessment", 2)
+    return PipelineContext(
+        out_path=tmp_path / "out.xlsx",
+        template_xlsx=template,
+        question_sheet="Assessment",
+        header_row=2,
+    )
+
+
+def test_pipeline_end_to_end_writes_output(tmp_path, ctx):
+    pdf = tmp_path / "in.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    pipeline = PipelineV1(PipelineConfig(), ctx)
+    out = pipeline(pdf)
+    assert out == ctx.out_path
+    assert load_workbook(out).sheetnames == ["Assessment"]
+
+
+def test_pipeline_with_all_stages_disabled_still_writes(tmp_path, ctx):
+    """Every stage toggle off must not crash — output stage always runs regardless."""
+    pdf = tmp_path / "in.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    cfg = PipelineConfig()
+    for name in ("extraction", "classification", "gate", "llm", "merge", "mapping"):
+        setattr(cfg.stages, name, False)
+    pipeline = PipelineV1(cfg, ctx)
+    out = pipeline(pdf)
+    assert out.exists()
+
+
+def test_build_pipeline_does_not_construct_bedrock_without_with_llm(ctx, monkeypatch):
+    """Default: no Bedrock client built — so no AWS deps required."""
+    called = {"n": 0}
+
+    def _boom(*a, **kw):
+        called["n"] += 1
+        raise AssertionError("bedrock client should not be built")
+
+    monkeypatch.setattr(
+        "pdftoxl.pipeline_v1.pipeline.build_bedrock_client", _boom
+    )
+    pipeline = build_pipeline(PipelineConfig(), ctx, with_llm=False)
+    assert isinstance(pipeline, PipelineV1)
+    assert pipeline._llm_client is None
+    assert called["n"] == 0
+
+
+def test_build_pipeline_constructs_client_when_with_llm_true(ctx, monkeypatch):
+    sentinel = object()
+    captured = {}
+
+    def _fake_build(settings):
+        captured["settings"] = settings
+        return sentinel
+
+    monkeypatch.setattr(
+        "pdftoxl.pipeline_v1.pipeline.build_bedrock_client", _fake_build
+    )
+    cfg = PipelineConfig()
+    pipeline = build_pipeline(cfg, ctx, with_llm=True)
+    assert pipeline._llm_client is sentinel
+    assert captured["settings"].model_id == cfg.bedrock.model_id
+    assert captured["settings"].region == cfg.bedrock.region
+
+
+def test_build_pipeline_skips_client_when_llm_stage_disabled(ctx, monkeypatch):
+    """with_llm=True but stages.llm=False → still no client (avoids wasted AWS init)."""
+    monkeypatch.setattr(
+        "pdftoxl.pipeline_v1.pipeline.build_bedrock_client",
+        lambda s: (_ for _ in ()).throw(AssertionError("should not build")),
+    )
+    cfg = PipelineConfig()
+    cfg.stages.llm = False
+    pipeline = build_pipeline(cfg, ctx, with_llm=True)
+    assert pipeline._llm_client is None

--- a/tests/unit/test_pipeline_v1_stages.py
+++ b/tests/unit/test_pipeline_v1_stages.py
@@ -1,0 +1,151 @@
+"""Unit tests for each PipelineV1 stage's `run` function."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from openpyxl import Workbook, load_workbook
+
+from pdftoxl.pipeline_v1.stages import (
+    classification,
+    extraction,
+    gate,
+    llm,
+    mapping,
+    merge,
+    output,
+)
+
+
+def test_extraction_returns_empty_blocks_for_any_path(tmp_path):
+    pdf = tmp_path / "dummy.pdf"
+    pdf.write_bytes(b"%PDF-1.4 stub")
+    raw = extraction.run(pdf)
+    assert raw.pdf_path == pdf
+    assert raw.blocks == []
+
+
+def test_classification_passes_blocks_through():
+    raw = extraction.RawBlocks(pdf_path=Path("x"), blocks=[{"a": 1}, {"a": 2}])
+    out = classification.run(raw)
+    assert out.blocks == raw.blocks
+
+
+def test_gate_splits_by_confidence_threshold():
+    classified = classification.ClassifiedBlocks(
+        blocks=[
+            {"id": 1, "confidence": 0.9},
+            {"id": 2, "confidence": 0.5},
+            {"id": 3, "confidence": 0.75},  # boundary is accepted (>=)
+            {"id": 4},  # missing confidence → 0.0 → deferred
+        ]
+    )
+    out = gate.run(classified, confidence_threshold=0.75)
+    accepted_ids = {b["id"] for b in out.accepted}
+    deferred_ids = {b["id"] for b in out.deferred}
+    assert accepted_ids == {1, 3}
+    assert deferred_ids == {2, 4}
+
+
+def test_gate_handles_empty_input():
+    out = gate.run(classification.ClassifiedBlocks(blocks=[]), confidence_threshold=0.5)
+    assert out.accepted == [] and out.deferred == []
+
+
+def test_llm_skips_when_no_client():
+    gated = gate.GateOutput(accepted=[], deferred=[{"id": 1}])
+    out = llm.run(gated, client=None)
+    assert out.enriched == gated.deferred
+
+
+def test_llm_skips_when_no_deferred_even_with_client():
+    class _FakeClient:
+        def invoke(self, prompt, *, system=None):
+            raise AssertionError("should not be called")
+
+    gated = gate.GateOutput(accepted=[{"id": 1}], deferred=[])
+    out = llm.run(gated, client=_FakeClient())
+    assert out.enriched == []
+
+
+def test_llm_with_client_and_deferred_returns_blocks_unchanged():
+    """The scaffold does not mutate — it just round-trips deferred blocks."""
+
+    class _FakeClient:
+        def invoke(self, prompt, *, system=None):
+            return "ignored"
+
+    deferred = [{"id": 1, "confidence": 0.1}]
+    gated = gate.GateOutput(accepted=[], deferred=deferred)
+    out = llm.run(gated, client=_FakeClient())
+    assert out.enriched == deferred
+
+
+def test_merge_combines_and_filters_by_min_confidence():
+    gated = gate.GateOutput(
+        accepted=[{"id": 1, "confidence": 0.9}, {"id": 2}],  # id=2 missing → defaults to 1.0
+        deferred=[],
+    )
+    llm_out = llm.LLMOutput(
+        enriched=[{"id": 3, "confidence": 0.04}, {"id": 4, "confidence": 0.5}]
+    )
+    merged = merge.run(gated, llm_out, min_confidence=0.05)
+    ids = [b["id"] for b in merged.blocks]
+    # id=3 drops (below threshold); id=2 survives because default is 1.0.
+    assert ids == [1, 2, 4]
+
+
+def test_mapping_returns_empty_scaffold():
+    merged = merge.MergedBlocks(blocks=[{"id": 1}])
+    mapped = mapping.run(merged)
+    assert mapped.rows == []
+
+
+def _fake_template(path: Path, sheet: str, header_row: int) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = sheet
+    for col in range(1, 5):
+        ws.cell(row=header_row, column=col, value=f"H{col}")
+    # Dummy data rows that should be cleared on output.
+    ws.cell(row=header_row + 1, column=1, value="existing-1")
+    ws.cell(row=header_row + 2, column=2, value="existing-2")
+    wb.save(path)
+
+
+def test_output_clones_template_and_clears_rows_below_header(tmp_path):
+    template = tmp_path / "template.xlsx"
+    _fake_template(template, sheet="Assessment", header_row=3)
+    out_path = tmp_path / "nested" / "out.xlsx"
+    written = output.run(
+        mapping.MappedRows(rows=[]),
+        out_path=out_path,
+        template_xlsx=template,
+        question_sheet="Assessment",
+        header_row=3,
+    )
+    assert written == out_path
+    assert out_path.exists()
+    wb = load_workbook(out_path)
+    ws = wb["Assessment"]
+    # Header preserved.
+    assert ws.cell(row=3, column=1).value == "H1"
+    # Rows below header cleared.
+    assert ws.cell(row=4, column=1).value is None
+    assert ws.cell(row=5, column=2).value is None
+
+
+def test_output_tolerates_missing_sheet(tmp_path):
+    """If the question sheet is absent, output should still produce a valid file."""
+    template = tmp_path / "template.xlsx"
+    _fake_template(template, sheet="Other", header_row=2)
+    out_path = tmp_path / "out.xlsx"
+    written = output.run(
+        mapping.MappedRows(rows=[]),
+        out_path=out_path,
+        template_xlsx=template,
+        question_sheet="NotThere",
+        header_row=2,
+    )
+    assert written.exists()
+    wb = load_workbook(written)
+    assert "Other" in wb.sheetnames


### PR DESCRIPTION
Closes #4.

## Summary
- New `src/pdftoxl/pipeline_v1/` with `PipelineV1` satisfying the `Pipeline` protocol, plus seven stage modules (extraction → classification → gate → llm → merge → mapping → output) as independent stubs so later PRs can fill them in.
- New `src/pdftoxl/cli.py` (Typer) registered as `pdftoxl` in `pyproject.toml`: `pdftoxl run --fixture FX-… --out /tmp/x.xlsx [--with-llm] [--config …]`.
- `PipelineConfig` via pydantic-settings with precedence `--config` → `PDFTOXL_CONFIG` → `./config.yaml` → defaults, and `PDFTOXL_*__*` env overrides.
- Bedrock / dotenv / structlog wrapped in `src/pdftoxl/adapters/` so stages stay SDK-free.
- `tests/integration/test_pipeline_v1_smoke.py` runs the empty pipeline on FX-TXLTSS-001 and asserts the output workbook opens.
- New deps: `pydantic-settings`, `python-dotenv`, `structlog`, `boto3`. `.env` added to `.gitignore`; `.env.example` documents the AWS + Bedrock vars.

## Test plan
- [ ] `make lint`
- [ ] `make test`
- [ ] `pdftoxl run --fixture FX-TXLTSS-001 --out /tmp/x.xlsx` exits 0 and writes a valid workbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)